### PR TITLE
All Expansion tab implemented

### DIFF
--- a/src/components/UserMounts/UserMountsTablePanel.js
+++ b/src/components/UserMounts/UserMountsTablePanel.js
@@ -36,14 +36,14 @@ export const UserMountsTablePanel = (props) => {
     )
     .sort((a, b) => a.username.localeCompare(b.username));
 
-  const filteredMounts = props.mounts.filter(selectedExpansion !== 1 ? (
+  const filteredMounts = props.mounts.filter(selectedExpansion !== -1 ? (
     (mount) => mount.expansion === selectedExpansion
     ) : (
       (mount) => mount
     )
   );
 
-  const filteredUserMounts = props.userMounts.filter(selectedExpansion !== 1 ? (
+  const filteredUserMounts = props.userMounts.filter(selectedExpansion !== -1 ? (
     (userMount) => userMount.expansion === selectedExpansion
     ) : (
       (userMount) => userMount
@@ -60,14 +60,14 @@ export const UserMountsTablePanel = (props) => {
         centered
       >
         <Tab
+          onClick={() => changeSelectedTab(-1)}
+          label={EXPANSION_MAP["-1"]}
+          value={-1}
+        />
+        <Tab
           onClick={() => changeSelectedTab(0)}
           label={EXPANSION_MAP[0]}
           value={0}
-        />
-        <Tab
-          onClick={() => changeSelectedTab(1)}
-          label={EXPANSION_MAP[1]}
-          value={1}
         />
         <Tab
           onClick={() => changeSelectedTab(2)}

--- a/src/components/UserMounts/UserMountsTablePanel.js
+++ b/src/components/UserMounts/UserMountsTablePanel.js
@@ -15,10 +15,6 @@ export const UserMountsTablePanel = (props) => {
     setSelectedExpansion(expansion);
   };
 
-  const filteredUserMounts = props.userMounts.filter(
-    (userMount) => userMount.expansion === selectedExpansion
-  );
-
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(ROWS_PER_PAGE_OPTIONS[0]);
   const handleChangePage = (e, newPage) => {
@@ -40,6 +36,20 @@ export const UserMountsTablePanel = (props) => {
     )
     .sort((a, b) => a.username.localeCompare(b.username));
 
+  const filteredMounts = props.mounts.filter(selectedExpansion !== 1 ? (
+    (mount) => mount.expansion === selectedExpansion
+    ) : (
+      (mount) => mount
+    )
+  );
+
+  const filteredUserMounts = props.userMounts.filter(selectedExpansion !== 1 ? (
+    (userMount) => userMount.expansion === selectedExpansion
+    ) : (
+      (userMount) => userMount
+    )
+  );
+
   return (
     <>
       <Tabs
@@ -53,6 +63,11 @@ export const UserMountsTablePanel = (props) => {
           onClick={() => changeSelectedTab(0)}
           label={EXPANSION_MAP[0]}
           value={0}
+        />
+        <Tab
+          onClick={() => changeSelectedTab(1)}
+          label={EXPANSION_MAP[1]}
+          value={1}
         />
         <Tab
           onClick={() => changeSelectedTab(2)}
@@ -76,9 +91,7 @@ export const UserMountsTablePanel = (props) => {
         />
       </Tabs>
       <UserMountsTable
-        mounts={props.mounts.filter(
-          (mount) => mount.expansion === selectedExpansion
-        )}
+        mounts={filteredMounts}
         users={filteredUsers.slice(
           page * rowsPerPage,
           page * rowsPerPage + rowsPerPage

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -43,6 +43,7 @@ export const ADD_USER_BUTTON = "Add User";
 export const EXPANSION_COLUMN = "Expansion";
 
 export const EXPANSION_MAP = {
+  "-1": "all",
   0: "Misc.",
   1: "All",
   2: "A Realm Reborn",

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -43,9 +43,8 @@ export const ADD_USER_BUTTON = "Add User";
 export const EXPANSION_COLUMN = "Expansion";
 
 export const EXPANSION_MAP = {
-  "-1": "all",
+  "-1": "All",
   0: "Misc.",
-  1: "All",
   2: "A Realm Reborn",
   3: "Heavensward",
   4: "Stormblood",

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -44,6 +44,7 @@ export const EXPANSION_COLUMN = "Expansion";
 
 export const EXPANSION_MAP = {
   0: "Misc.",
+  1: "All",
   2: "A Realm Reborn",
   3: "Heavensward",
   4: "Stormblood",


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
no ability to display all expansion userMounts on one table

Issue Number: [3](https://github.com/sofia819/mount_recorder_client/issues/3)


## What is the new behavior?
A new all tab displays all expansion userMounts on one table


## Other information
column spacing breaks on this table
edit modal does not function correctly displaying so many mounts
![All Tab](https://user-images.githubusercontent.com/30082233/92419864-01e0d680-f13e-11ea-9289-4aaa6abe0b92.gif)
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
