### PR TITLE
[31] Fix close button on UserMounts form

### DIFF
--- a/src/components/UserMounts/EditUserMounts/EditUserMountsButton.js
+++ b/src/components/UserMounts/EditUserMounts/EditUserMountsButton.js
@@ -1,14 +1,17 @@
-import React, { createRef, useState, useEffect } from "react";
-import { Button, Modal } from "@material-ui/core";
-import { EditUserMountsForm } from "components/UserMounts/EditUserMounts/EditUserMountsForm";
-import { updateUserMountsService } from "services/userMountsServices";
-import PropTypes from "prop-types";
+import React, { createRef, useState, useEffect } from 'react';
+import { Button, Modal } from '@material-ui/core';
+import { EditUserMountsForm } from 'components/UserMounts/EditUserMounts/EditUserMountsForm';
+import { updateUserMountsService } from 'services/userMountsServices';
+import PropTypes from 'prop-types';
 
 export const EditUserMountsButton = (props) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleOpenModal = () => setIsModalOpen(true);
-  const handleCloseModal = () => setIsModalOpen(false);
+  const handleCloseModal = () => {
+    setUserMounts(props.userMounts);
+    setIsModalOpen(false);
+  };
 
   const [userMounts, setUserMounts] = useState(props.userMounts);
 
@@ -64,13 +67,16 @@ export const EditUserMountsButton = (props) => {
   useEffect(() => setUserMounts(props.userMounts), [props.userMounts]);
 
   return (
-    <Button variant="outlined" color="primary" onClick={handleOpenModal}>
-      {props.username}
+    <>
+      <Button variant='outlined' color='primary' onClick={handleOpenModal}>
+        {props.username}
+      </Button>
       <Modal
         open={isModalOpen}
         onClose={handleCloseModal}
-        aria-labelledby="simple-modal-title"
-        aria-describedby="simple-modal-description"
+        disableBackdropClick
+        aria-labelledby='simple-modal-title'
+        aria-describedby='simple-modal-description'
       >
         <EditUserMountsForm
           username={props.username}
@@ -78,9 +84,10 @@ export const EditUserMountsButton = (props) => {
           updateUserMounts={updateUserMounts}
           userMounts={userMounts}
           onChangeSelection={handleChangeSelection}
+          onCloseModal={handleCloseModal}
         />
       </Modal>
-    </Button>
+    </>
   );
 };
 

--- a/src/components/UserMounts/EditUserMounts/EditUserMountsForm.js
+++ b/src/components/UserMounts/EditUserMounts/EditUserMountsForm.js
@@ -49,7 +49,7 @@ export const EditUserMountsForm = forwardRef((props, ref) => {
             </Button>
           </Grid>
           <Grid item xs={6}>
-            <Button variant='contained' onClick={props.updateUserMounts}>
+            <Button variant='contained' onClick={props.onCloseModal}>
               {CLOSE_BUTTON}
             </Button>
           </Grid>
@@ -63,4 +63,5 @@ EditUserMountsForm.propTypes = {
   onChangeSelection: PropTypes.func,
   userMounts: PropTypes.array,
   updateUserMounts: PropTypes.func,
+  onCloseModal: PropTypes.func,
 };


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## Issue
- [31](https://github.com/sofia819/mount_recorder_client/issues/31)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- If the user clicks on `Close` on the User Mounts edit form, the data will get updated.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- If the user clicks on `Close` on the user mounts form, the modal will close and the state will be reset.

## Other information
![gif](https://user-images.githubusercontent.com/17885737/93790449-0d81d200-fc01-11ea-8b29-c61b0ec604ad.gif)
